### PR TITLE
Fixes reading palette moving reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcx"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["kryptan"]
 description = "Library for reading & writing PCX images."
 documentation = "https://docs.rs/pcx/"

--- a/src/low_level/rle.rs
+++ b/src/low_level/rle.rs
@@ -23,8 +23,8 @@ impl<S: io::Read> Decompressor<S> {
     }
 
     /// Stop decompression process and get underlying stream.
-    pub fn finish(self) -> S {
-        self.stream
+    pub fn finish(&mut self) -> &mut S {
+        &mut self.stream
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -241,6 +241,10 @@ impl<R: io::Read> Reader<R> {
     /// Returns number of colors in palette or zero if there is no palette. The actual number of bytes written to the output buffer is
     /// equal to the returned value multiplied by 3. Format of the output buffer is R, G, B, R, G, B, ...
     pub fn read_palette(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let length = self.header.palette_length();
+
+        assert!(length.is_none() || buffer.len() >= length.unwrap() as usize, format!("Provided buffer length {} is insufficient. Require {} ", buffer.len(), length.unwrap()));
+
         match self.header.palette_length() {
             Some(2) => {
                 // Special case - monochrome image.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -116,7 +116,7 @@ impl<R: io::Read> Reader<R> {
                         }
                     }
                 }
-            };
+            }
 
             // Unpack packed bits into bytes.
             match self.header.bit_depth {
@@ -240,7 +240,7 @@ impl<R: io::Read> Reader<R> {
     ///
     /// Returns number of colors in palette or zero if there is no palette. The actual number of bytes written to the output buffer is
     /// equal to the returned value multiplied by 3. Format of the output buffer is R, G, B, R, G, B, ...
-    pub fn read_palette(self, buffer: &mut [u8]) -> io::Result<usize> {
+    pub fn read_palette(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
         match self.header.palette_length() {
             Some(2) => {
                 // Special case - monochrome image.
@@ -257,7 +257,7 @@ impl<R: io::Read> Reader<R> {
 
                 return Ok(2 as usize);
             }
-            Some(palette_length @ 1...16) => {
+            Some(palette_length @ 1..=16) => {
                 // Palettes of 16 colors or smaller are stored in the header.
                 for i in 0..(palette_length as usize) {
                     (&mut buffer[(i * 3)..((i + 1) * 3)]).copy_from_slice(&self.header.palette[i]);
@@ -271,7 +271,7 @@ impl<R: io::Read> Reader<R> {
         }
 
         // Stop decompressing and continue reading underlying stream.
-        let mut stream = match self.pixel_reader {
+        let stream = match &mut self.pixel_reader {
             PixelReader::Compressed(decompressor) => decompressor.finish(),
             PixelReader::NotCompressed(stream) => stream,
         };


### PR DESCRIPTION
changes `Reader.read_palette `to have signature &mut self instead of self
otherwise reading the palette moves the Reader, requiring to create to Readers of the to be read file, in order to process a palatted pcx
consequently has to change `Decompressor.finish` from `(self) -> S` to` (&mut self) -> &mut S`

i also replaced ... with ..=, and removed an unnecessary semicolon 

i bumped the minor version, because this is a breaking API change

this is not ready to merge yet, as i have not tested for unintended side-effects of the change yet